### PR TITLE
Terraformer.parse can take a File instance too

### DIFF
--- a/lib/terraformer.rb
+++ b/lib/terraformer.rb
@@ -45,7 +45,7 @@ module Terraformer
   # is determined by +type+ property.
   #
   def self.parse geojson
-    if geojson.is_a?(String) or geojson.is_a?(File)
+    if geojson.is_a?(String) or geojson.respond_to?(:read)
       geojson = File.read geojson if File.readable? geojson
       geojson = JSON.parse geojson
     end

--- a/test/terraformer_spec.rb
+++ b/test/terraformer_spec.rb
@@ -63,6 +63,16 @@ describe Terraformer do
       p.coordinates.must_equal Terraformer::Coordinate.new 100, 0
     end
 
+    it 'parses the target of a Pathname' do
+      require "pathname"
+      path = Pathname.new('test/examples/point.geojson')
+      p = Terraformer.parse path
+      p.dont_be_terrible_ok
+      p.type.must_equal 'Point'
+      p.coordinates.must_be_instance_of Terraformer::Coordinate
+      p.coordinates.must_equal Terraformer::Coordinate.new 100, 0
+    end
+
     it 'parses polygons' do
       p = Terraformer.parse EXAMPLES[:polygon]
       p.dont_be_terrible_ok


### PR DESCRIPTION
The comment states `Terraformer.parse` could take a `File` but the implementation didn't support it. Now, it does!
